### PR TITLE
Patched UriResolver for PHP 8 compatibility.

### DIFF
--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -109,7 +109,7 @@ class UriResolver implements UriResolverInterface
         if ($relativePath == '') {
             return $basePath;
         }
-        if ($relativePath{0} == '/') {
+        if (str_starts_with($relativePath, '/')) {
             return $relativePath;
         }
 


### PR DESCRIPTION
This change was made in support of an internal service that uses this library. 

The 2.x tag/branch is roughly 5 years old and unlikely to change.